### PR TITLE
根据需求改变：已有占位图的时候再次reloadData会重新请求占位图而不是直接返回（用于从一个占位图直接切换到其他种类占位图的情况）

### DIFF
--- a/CYLTableViewPlaceHolder/UITableView+CYLTableViewPlaceHolder.m
+++ b/CYLTableViewPlaceHolder/UITableView+CYLTableViewPlaceHolder.m
@@ -63,7 +63,11 @@
             self.scrollWasEnabled = self.scrollEnabled;
             BOOL scrollEnabled = NO;
             if ([self respondsToSelector:@selector(enableScrollWhenPlaceHolderViewShowing)]) {
-                 scrollEnabled = [self performSelector:@selector(enableScrollWhenPlaceHolderViewShowing)];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wint-conversion"
+                scrollEnabled = [self performSelector:@selector(enableScrollWhenPlaceHolderViewShowing)];
+#pragma clang diagnostic pop
+                
                 if (!scrollEnabled) {
                     NSString *reason = @"There is no need to return  NO for `-enableScrollWhenPlaceHolderViewShowing`, it will be NO by default";
                     @throw [NSException exceptionWithName:NSGenericException
@@ -71,7 +75,11 @@
                                                  userInfo:nil];
                 }
             } else if ([self.delegate respondsToSelector:@selector(enableScrollWhenPlaceHolderViewShowing)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wint-conversion"
                 scrollEnabled = [self.delegate performSelector:@selector(enableScrollWhenPlaceHolderViewShowing)];
+#pragma clang diagnostic pop
+                
                 if (!scrollEnabled) {
                     NSString *reason = @"There is no need to return  NO for `-enableScrollWhenPlaceHolderViewShowing`, it will be NO by default";
                     @throw [NSException exceptionWithName:NSGenericException
@@ -101,8 +109,15 @@
     } else if (isEmpty) {
         // Make sure it is still above all siblings.
         [self.placeHolderView removeFromSuperview];
+        if ([self respondsToSelector:@selector(makePlaceHolderView)]) {
+            self.placeHolderView = [self performSelector:@selector(makePlaceHolderView)];
+        } else if ( [self.delegate respondsToSelector:@selector(makePlaceHolderView)]) {
+            self.placeHolderView = [self.delegate performSelector:@selector(makePlaceHolderView)];
+        }
+        self.placeHolderView.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
         [self addSubview:self.placeHolderView];
     }
 }
 
 @end
+


### PR DESCRIPTION
类似于从无数据占位图直接切换到无网络占位图的情况，调用reloadData会重新获取代理方法的返回